### PR TITLE
FIX liquibase#2727: correct check for BOOLEAN

### DIFF
--- a/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
+++ b/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
@@ -1,8 +1,11 @@
 package liquibase.ext.db2i.database;
 
+import liquibase.Scope;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.DB2Database;
 import liquibase.exception.DatabaseException;
+import liquibase.executor.ExecutorService;
+import liquibase.statement.core.RawSqlStatement;
 
 public class DB2iDatabase extends DB2Database {
 
@@ -37,5 +40,21 @@ public class DB2iDatabase extends DB2Database {
     @Override
     public boolean supportsSchemas() {
         return true;
+    }
+
+    @Override
+	public boolean supportsBooleanDataType() {
+        if (getConnection() == null)
+            return false;
+        try {
+            final Integer countBooleanType = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).queryForObject(
+                    new RawSqlStatement("select count(*) from sysibm.sqltypeinfo where type_name = 'BOOLEAN';"),
+                    Integer.class);
+            if (countBooleanType == 1)
+                return true;
+        } catch (final Exception e) {
+            Scope.getCurrentScope().getLog(getClass()).info("Error checking for BOOLEAN type", e);
+        }
+        return false;
     }
 }

--- a/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
+++ b/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
@@ -50,8 +50,7 @@ public class DB2iDatabase extends DB2Database {
             final Integer countBooleanType = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).queryForObject(
                     new RawSqlStatement("select count(*) from sysibm.sqltypeinfo where type_name = 'BOOLEAN'"),
                     Integer.class);
-            if (countBooleanType == 1)
-                return true;
+            return countBooleanType == 1;
         } catch (final Exception e) {
             Scope.getCurrentScope().getLog(getClass()).info("Error checking for BOOLEAN type", e);
         }

--- a/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
+++ b/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
@@ -48,7 +48,7 @@ public class DB2iDatabase extends DB2Database {
             return false;
         try {
             final Integer countBooleanType = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).queryForObject(
-                    new RawSqlStatement("select count(*) from sysibm.sqltypeinfo where type_name = 'BOOLEAN';"),
+                    new RawSqlStatement("select count(*) from sysibm.sqltypeinfo where type_name = 'BOOLEAN'"),
                     Integer.class);
             if (countBooleanType == 1)
                 return true;


### PR DESCRIPTION
override `supportsBooleanDataType` and direct check for BOOLEAN in the build-in type db2i specific catalog