### PR TITLE
[DAT-22483] Implement target uniqueness for DB2 iSeries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,15 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <liquibase.version>5.0.2</liquibase.version>
+    <liquibase.version>5.2.0</liquibase.version>
   </properties>
   <dependencies>
-	</dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
+++ b/src/main/java/liquibase/ext/db2i/database/DB2iDatabase.java
@@ -3,6 +3,7 @@ package liquibase.ext.db2i.database;
 import liquibase.Scope;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.DB2Database;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
@@ -55,5 +56,16 @@ public class DB2iDatabase extends DB2Database {
             Scope.getCurrentScope().getLog(getClass()).info("Error checking for BOOLEAN type", e);
         }
         return false;
+    }
+
+    /**
+     * DB2 iSeries is the only DB2 variant with {@code supportsSchemas()=true}. Without this override,
+     * the base implementation returns the library/collection name as both {@code catalog} AND
+     * {@code schema} in the target uniqueness attributes (because in DB2 the catalog slot holds the
+     * authorization ID, which on iSeries equals the current library).
+     */
+    @Override
+    protected String resolveSchema(JdbcConnection jdbcConn) {
+        return null;
     }
 }

--- a/src/test/java/liquibase/ext/db2i/database/DB2iDatabaseTest.java
+++ b/src/test/java/liquibase/ext/db2i/database/DB2iDatabaseTest.java
@@ -1,13 +1,112 @@
 package liquibase.ext.db2i.database;
 
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.license.TargetUniquenessAttributes;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import static junit.framework.TestCase.assertEquals;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 
 public class DB2iDatabaseTest {
 
     @Test
     public void getShortName() {
         assertEquals("db2i", new DB2iDatabase().getShortName());
+    }
+
+    // ---- Target Uniqueness ----
+
+    @Test
+    public void getTargetUniquenessAttributes_returnsDatabaseNameAsDb2iAndSchemaAsNull() throws Exception {
+        DB2iDatabase db = new DB2iDatabase();
+        db.setDefaultCatalogName("MYLIB");
+        db.setConnection(mockDb2iConnection("jdbc:as400://host/MYLIB", "MYLIB"));
+
+        TargetUniquenessAttributes attrs = db.getTargetUniquenessAttributes();
+
+        assertEquals("jdbc:as400://host/MYLIB", attrs.getSanitizedUrl());
+        assertEquals("DB2i", attrs.getDatabaseName());
+        assertEquals("MYLIB", attrs.getCatalog());
+        assertNull(attrs.getSchema());
+    }
+
+    /**
+     * Core licensing assertion for DB2 iSeries: the license unit is the library (collection),
+     * stored in Liquibase's catalog slot via SELECT CURRENT SCHEMA. Two connections to the same
+     * iSeries system targeting different libraries must count as two distinct targets.
+     */
+    @Test
+    public void getTargetUniquenessAttributes_db2iDifferentLibraries_produceDifferentTargetIds() throws Exception {
+        DB2iDatabase db1 = new DB2iDatabase();
+        db1.setDefaultCatalogName("MYLIB");
+        db1.setConnection(mockDb2iConnection("jdbc:as400://host/MYLIB", "MYLIB"));
+        DB2iDatabase db2 = new DB2iDatabase();
+        db2.setDefaultCatalogName("OTHERLIB");
+        db2.setConnection(mockDb2iConnection("jdbc:as400://host/OTHERLIB", "OTHERLIB"));
+
+        TargetUniquenessAttributes attrs1 = db1.getTargetUniquenessAttributes();
+        TargetUniquenessAttributes attrs2 = db2.getTargetUniquenessAttributes();
+
+        assertNotEquals(attrs1.getTargetId(), attrs2.getTargetId());
+    }
+
+    /**
+     * DB2 iSeries has {@code supportsSchemas()=true}, so the base implementation would include
+     * {@code connection.getSchema()} in the canonical string. That would cause two connections
+     * to the same library but with different current schemas to produce different target IDs —
+     * violating the Target Uniqueness Definitions. Our {@code resolveSchema()} override nullifies
+     * the schema so these collapse correctly.
+     */
+    @Test
+    public void getTargetUniquenessAttributes_db2iSameLibraryDifferentUnderlyingSchema_produceSameTargetId() throws Exception {
+        DB2iDatabase db1 = new DB2iDatabase();
+        db1.setDefaultCatalogName("MYLIB");
+        db1.setConnection(mockDb2iConnection("jdbc:as400://host/MYLIB", "MYLIB"));
+        DB2iDatabase db2 = new DB2iDatabase();
+        db2.setDefaultCatalogName("MYLIB");
+        db2.setConnection(mockDb2iConnection("jdbc:as400://host/MYLIB", "OTHERSCHEMA"));
+
+        TargetUniquenessAttributes attrs1 = db1.getTargetUniquenessAttributes();
+        TargetUniquenessAttributes attrs2 = db2.getTargetUniquenessAttributes();
+
+        assertEquals(attrs1.getTargetId(), attrs2.getTargetId());
+    }
+
+    /**
+     * Mock a DB2 iSeries JDBC connection. Detection in {@link DB2iDatabase#isCorrectDatabaseImplementation}
+     * relies on product name starting with {@code "DB2 UDB for AS/400"}. Tests set
+     * {@code defaultCatalogName} on the database directly to skip the live
+     * {@code SELECT CURRENT SCHEMA} query.
+     */
+    private JdbcConnection mockDb2iConnection(String url, String schema) throws Exception {
+        JdbcConnection jdbcConn = Mockito.mock(JdbcConnection.class);
+        Connection underlying = Mockito.mock(Connection.class);
+        DatabaseMetaData metadata = Mockito.mock(DatabaseMetaData.class);
+        Statement statement = Mockito.mock(Statement.class);
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+        when(jdbcConn.getURL()).thenReturn(url);
+        when(jdbcConn.getCatalog()).thenReturn(null);
+        when(jdbcConn.getAutoCommit()).thenReturn(false);
+        when(jdbcConn.getUnderlyingConnection()).thenReturn(underlying);
+        when(jdbcConn.getDatabaseProductName()).thenReturn("DB2 UDB for AS/400");
+        when(jdbcConn.getDatabaseProductVersion()).thenReturn("07.04.0000 V7R4m0");
+        when(jdbcConn.isClosed()).thenReturn(false);
+        when(jdbcConn.createStatement()).thenReturn(statement);
+        when(statement.executeQuery(Mockito.anyString())).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(false);
+        when(underlying.getSchema()).thenReturn(schema);
+        when(underlying.getMetaData()).thenReturn(metadata);
+        when(metadata.supportsMixedCaseIdentifiers()).thenReturn(false);
+
+        return jdbcConn;
     }
 }


### PR DESCRIPTION
DB2 iSeries is the only DB2 variant with supportsSchemas()=true, which would cause the base implementation to include the library name as both catalog AND schema in target uniqueness attributes. Per the Target Uniqueness Definitions (OD#7 resolved), only the catalog (library) should identify the target.

Changes:
- Override resolveSchema() in DB2iDatabase to return null, keeping the canonical target representation consistent with LUW and z/OS.
- Bump liquibase.version from 5.0.2 to 5.2.0 to pick up the AbstractDb2Database.resolveCatalog() override from liquibase-pro DAT-22483 (delegates to getDefaultCatalogName(), which queries SELECT CURRENT SCHEMA FROM SYSIBM.SYSDUMMY1).
- Add Mockito test dependency (version inherited from liquibase-parent-pom).
- Add unit tests verifying canonical attributes, library-based target differentiation, and schema nullification.

No integration test: iSeries runs only on IBM Power hardware (OS/400) and has no Docker/TestContainers option. QA must verify on a real iSeries system.